### PR TITLE
Update to sort GH releases by publish time with unit test

### DIFF
--- a/neon_phal_plugin_core_updater/__init__.py
+++ b/neon_phal_plugin_core_updater/__init__.py
@@ -25,11 +25,12 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from os.path import isfile
-from typing import List
 
 import requests
 
+from os.path import isfile
+from typing import List
+from datetime import datetime
 from os import close
 from subprocess import Popen
 from tempfile import mkstemp
@@ -66,8 +67,12 @@ class CoreUpdater(PHALPlugin):
         """
         Get GitHub release names in reverse-chronological order (newest first).
         """
+        default_time = "2000-01-01T00:00:00Z"
         url = f'https://api.github.com/repos/{self.github_ref}/releases'
-        releases = requests.get(url).json()
+        releases: list = requests.get(url).json()
+        releases.sort(key=lambda r: datetime.strptime(r.get('created_at',
+                                                            default_time),
+                                                      "%Y-%m-%dT%H:%M:%SZ"))
         return [r.get('name') for r in releases]
 
     def _get_pypi_releases(self):

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -27,10 +27,9 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+
 from unittest.mock import Mock
-
 from mycroft_bus_client import Message
-
 from neon_phal_plugin_core_updater import CoreUpdater
 from ovos_utils.messagebus import FakeBus
 
@@ -46,7 +45,36 @@ class PluginTests(unittest.TestCase):
     def test_get_github_releases(self):
         self.assertEqual(self.plugin.github_ref, "NeonGeckoCom/NeonCore")
         releases = self.plugin._get_github_releases()
+
+        def _parse_version(ver):
+            year, month, day = ver.split('.')
+            if 'a' in day:
+                day, alpha = day.split('a')
+            else:
+                alpha = 0
+            return int(year), int(month), int(day), int(alpha)
+
         self.assertIsInstance(releases, list)
+        for i, r in enumerate(releases):
+            if i == 0:
+                continue
+            new = _parse_version(r)
+            old = _parse_version(releases[i - 1])
+            self.assertGreaterEqual(new[0], old[0], f"new={new}|old={old}")
+            if new[0] == old[0]:
+                # Same year, month must be greater
+                self.assertGreaterEqual(new[1], old[1], f"new={new}|old={old}")
+                if new[1] == old[1]:
+                    # Same month, day must be greater
+                    self.assertGreaterEqual(new[2], old[2],
+                                            f"new={new}|old={old}")
+                    if new[2] == old[2]:
+                        if new[3] == 0:
+                            # Stable release, alpha versions will reset
+                            continue
+                        # Same day, alpha must be greater
+                        self.assertGreaterEqual(new[3], old[3],
+                                                f"new={new}|old={old}")
 
     def test_check_core_updates(self):
         self.assertIsNone(self.plugin.pypi_ref)


### PR DESCRIPTION
# Description
Previously, it was assumed that releases appeared in chronological order. This explicitly sorts GH releases by release timestamps

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
23.5.15a10 appears after 23.5.15a9 in [NeonCore releases](https://github.com/NeonGeckoCom/NeonCore/releases)