### PR TITLE
Update default update branch handling

### DIFF
--- a/neon_phal_plugin_core_updater/__init__.py
+++ b/neon_phal_plugin_core_updater/__init__.py
@@ -123,11 +123,16 @@ class CoreUpdater(PHALPlugin):
         """
         version = message.data.get("version", "")
         LOG.debug(f"Starting update to version: {version}")
+        default_branch = "dev" if "a" in version else "master"
         patch_ver = version.split('a')[0] if version else "master"
         if self.patch_script:
             patch_script = self.patch_script.format(patch_ver)
             LOG.info(f"Running patches from: {patch_script}")
             patch_script = requests.get(patch_script)
+            if not patch_script.ok:
+                LOG.info(f"No branch for {patch_ver}, trying {default_branch}")
+                patch_script = \
+                    requests.get(self.patch_script.format(default_branch))
             if patch_script.ok:
                 ref, temp_path = mkstemp()
                 close(ref)


### PR DESCRIPTION
# Description
Handle default `dev`/`master` branches in core update patches

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Previously, alpha releases followed a versioning scheme where only the alpha changed; now they are tied to date so it makes sense for alpha releases to track `dev` instead of daily branches