### PR TITLE
Prevent 'None' latest version returns

### DIFF
--- a/neon_phal_plugin_core_updater/__init__.py
+++ b/neon_phal_plugin_core_updater/__init__.py
@@ -110,6 +110,9 @@ class CoreUpdater(PHALPlugin):
 
         if new_version:
             LOG.info(f"Found newer version: {new_version}")
+        if not latest_version:
+            LOG.debug("Handling installed version as latest")
+            latest_version = self._installed_version
         LOG.info(f"Got latest version: {latest_version}")
         if message:
             self.bus.emit(message.response({"new_version": new_version,

--- a/neon_phal_plugin_core_updater/__init__.py
+++ b/neon_phal_plugin_core_updater/__init__.py
@@ -63,6 +63,14 @@ class CoreUpdater(PHALPlugin):
             LOG.warning(e)
             return "0.0.0"
 
+    def _get_latest_github_release(self) -> str:
+        """
+        Get the latest GitHub release
+        """
+        url = f'https://api.github.com/repos/{self.github_ref}/releases/latest'
+        release = requests.get(url).json()
+        return release.get('tag_name')
+
     def _get_github_releases(self) -> List[str]:
         """
         Get GitHub release names in reverse-chronological order (newest first).
@@ -110,9 +118,9 @@ class CoreUpdater(PHALPlugin):
 
         if new_version:
             LOG.info(f"Found newer version: {new_version}")
-        if not latest_version:
-            LOG.debug("Handling installed version as latest")
-            latest_version = self._installed_version
+        if not latest_version and self.github_ref:
+            LOG.info("No release found; get 'latest'")
+            latest_version = self._get_latest_github_release()
         LOG.info(f"Got latest version: {latest_version}")
         if message:
             self.bus.emit(message.response({"new_version": new_version,

--- a/neon_phal_plugin_core_updater/__init__.py
+++ b/neon_phal_plugin_core_updater/__init__.py
@@ -74,7 +74,7 @@ class CoreUpdater(PHALPlugin):
                                                             default_time),
                                                       "%Y-%m-%dT%H:%M:%SZ"),
                       reverse=True)
-        return [r.get('name') for r in releases]
+        return [r.get('tag_name') for r in releases]
 
     def _get_pypi_releases(self):
         # TODO: Implement package release checks
@@ -89,7 +89,7 @@ class CoreUpdater(PHALPlugin):
         new_version = None
         latest_version = None
         if self.pypi_ref:
-            releases = self._get_github_releases()
+            releases = self._get_pypi_releases()
         elif self.github_ref:
             releases = self._get_github_releases()
         else:
@@ -109,7 +109,8 @@ class CoreUpdater(PHALPlugin):
                 new_version = new_version or release
 
         if new_version:
-            LOG.info(f"Found newer release: {new_version}")
+            LOG.info(f"Found newer version: {new_version}")
+        LOG.info(f"Got latest version: {latest_version}")
         if message:
             self.bus.emit(message.response({"new_version": new_version,
                                             "latest_version": latest_version,

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -76,6 +76,12 @@ class PluginTests(unittest.TestCase):
                         self.assertGreaterEqual(new[3], old[3],
                                                 f"new={new}|old={old}")
 
+    def test_get_latest_github_release(self):
+        release = self.plugin._get_latest_github_release()
+        self.assertIsInstance(release, str, release)
+        self.assertEqual(len(release.split('.')), 3, release)
+        self.assertNotIn('a', release, release)
+
     def test_check_core_updates(self):
         self.assertIsNone(self.plugin.pypi_ref)
         real_get_releases = self.plugin._get_github_releases


### PR DESCRIPTION
# Description
Ensure plugin always reports the latest stable release in version checks

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->