### PR TITLE
Handle "Latest" and "Pre-release" GitHub tags

### DIFF
--- a/neon_phal_plugin_core_updater/__init__.py
+++ b/neon_phal_plugin_core_updater/__init__.py
@@ -98,8 +98,12 @@ class CoreUpdater(PHALPlugin):
         latest_version = None
         if self.pypi_ref:
             releases = self._get_pypi_releases()
-        elif self.github_ref:
+        elif self.github_ref and update_alpha:
+            # Get list of latest GH Releases
             releases = self._get_github_releases()
+        elif self.github_ref:
+            # Only need the "latest" GH Release
+            releases = [self._get_latest_github_release()]
         else:
             LOG.error("No remote reference to check for updates")
             releases = []
@@ -119,7 +123,7 @@ class CoreUpdater(PHALPlugin):
         if new_version:
             LOG.info(f"Found newer version: {new_version}")
         if not latest_version and self.github_ref:
-            LOG.info("No release found; get 'latest'")
+            LOG.warning("No release found; get 'latest'")
             latest_version = self._get_latest_github_release()
         LOG.info(f"Got latest version: {latest_version}")
         if message:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -85,8 +85,11 @@ class PluginTests(unittest.TestCase):
     def test_check_core_updates(self):
         self.assertIsNone(self.plugin.pypi_ref)
         real_get_releases = self.plugin._get_github_releases
-        gh_releases = ['22.10.1a1', '22.10.0', '22.04.1a1', '22.04.0']
+        real_get_latest = self.plugin._get_latest_github_release
+        # In this example, 22.10.3 is a pre-release
+        gh_releases = ['22.10.3', '22.10.1a1', '22.10.0', '22.04.1a1', '22.04.0']
         self.plugin._get_github_releases = Mock(return_value=gh_releases)
+        self.plugin._get_latest_github_release = Mock(return_value="22.10.0")
 
         # Check update already latest stable
         self.plugin._installed_version = "22.10.0"
@@ -137,6 +140,7 @@ class PluginTests(unittest.TestCase):
         self.assertEqual(resp.data['latest_version'], '22.10.0')
 
         self.plugin._get_github_releases = real_get_releases
+        self.plugin._get_latest_github_release = real_get_latest
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -87,7 +87,8 @@ class PluginTests(unittest.TestCase):
         real_get_releases = self.plugin._get_github_releases
         real_get_latest = self.plugin._get_latest_github_release
         # In this example, 22.10.3 is a pre-release
-        gh_releases = ['22.10.3', '22.10.1a1', '22.10.0', '22.04.1a1', '22.04.0']
+        gh_releases = ['22.10.3a1', '22.10.3', '22.10.1a1', '22.10.0',
+                       '22.04.1a1', '22.04.0']
         self.plugin._get_github_releases = Mock(return_value=gh_releases)
         self.plugin._get_latest_github_release = Mock(return_value="22.10.0")
 
@@ -112,8 +113,8 @@ class PluginTests(unittest.TestCase):
             "neon.core_updater.check_update",
             {"include_prerelease": True}))
         self.assertIsInstance(resp, Message)
-        self.assertEqual(resp.data['new_version'], '22.10.1a1')
-        self.assertEqual(resp.data['latest_version'], '22.10.1a1')
+        self.assertEqual(resp.data['new_version'], '22.10.3a1')
+        self.assertEqual(resp.data['latest_version'], '22.10.3a1')
 
         # Update from alpha to newer stable
         self.plugin._installed_version = "22.04.1a1"
@@ -128,8 +129,8 @@ class PluginTests(unittest.TestCase):
             "neon.core_updater.check_update",
             {"include_prerelease": True}))
         self.assertIsInstance(resp, Message)
-        self.assertEqual(resp.data['new_version'], '22.10.1a1')
-        self.assertEqual(resp.data['latest_version'], '22.10.1a1')
+        self.assertEqual(resp.data['new_version'], '22.10.3a1')
+        self.assertEqual(resp.data['latest_version'], '22.10.3a1')
 
         # Update from alpha to older stable
         self.plugin._installed_version = '22.10.1a1'


### PR DESCRIPTION
# Description
Instead of relying on parsing tags, explicitly use `Pre-release` and `Latest` GitHub tags
This allows for marking a "stable" version on GitHub as "Pre-release" to validate it before publication or to mark a problematic stable release as a pre-release to prevent updates

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->